### PR TITLE
#116 - proposed fix for IE11 ActiveXObject detection

### DIFF
--- a/fingerprint2.js
+++ b/fingerprint2.js
@@ -460,7 +460,8 @@
       }, this);
     },
     getIEPlugins: function () {
-      if(window.ActiveXObject){
+      if((Object.getOwnPropertyDescriptor && Object.getOwnPropertyDescriptor(window, "ActiveXObject")) ||
+          ("ActiveXObject" in window)){
         var names = [
           "AcroPDF.PDF", // Adobe PDF reader 7+
           "Adodb.Stream",

--- a/fingerprint2.js
+++ b/fingerprint2.js
@@ -460,6 +460,7 @@
       }, this);
     },
     getIEPlugins: function () {
+      var result = [];
       if((Object.getOwnPropertyDescriptor && Object.getOwnPropertyDescriptor(window, "ActiveXObject")) ||
           ("ActiveXObject" in window)){
         var names = [
@@ -487,7 +488,7 @@
           "rmocx.RealPlayer G2 Control.1"
         ];
         // starting to detect plugins in IE
-        return this.map(names, function(name){
+        result = this.map(names, function(name){
           try{
             new ActiveXObject(name); // eslint-disable-no-new
             return name;
@@ -495,9 +496,11 @@
             return null;
           }
         });
-      } else {
-        return [];
       }
+      if(navigator.plugins){
+        result = result.concat(this.getRegularPlugins());
+      }
+      return result;
     },
     pluginsShouldBeSorted: function () {
       var should = false;


### PR DESCRIPTION
The problem seems to be that IE11 detection of ActiveXObject returns undefined.  I got this solution from stackoverflow and seems to correctly detect.  But might be missing the main intent.  Please let me know what you think.  It seems there may also be opportunity to use navigator.plugins to increase the keys used in the hash.