### PR TITLE
Prevent false positives in font detection in Tor Browser

### DIFF
--- a/fingerprint2.js
+++ b/fingerprint2.js
@@ -421,7 +421,7 @@
         // creates a span and load the font to detect and a base font for fallback
         var createSpanWithFonts = function(fontToDetect, baseFont) {
             var s = createSpan();
-            s.style.fontFamily = fontToDetect + "," + baseFont;
+            s.style.fontFamily = "'" + fontToDetect + "'," + baseFont;
             return s;
         };
 


### PR DESCRIPTION
I discovered (OS X) that fingerprintjs2 reports a number of fonts in Tor Browser that are not actually present on the system. These false-positive fonts all have names containing a space and a numeral:
"Wingdings 2","Wingdings 3","Bauhaus 93","Bodoni 72","Bodoni 72 Oldstyle","Bodoni 72 Smallcaps","Bookshelf Symbol 7","English 111 Vivace BT","GeoSlab 703 Lt BT","GeoSlab 703 XBd BT","Humanst 521 Cn BT","Modern No. 20","Univers CE 55 Medium".

I found that adding quotes around the `fontToDetect` in the style.fontFamily attribute prevents the font from being falsely detected.