### PR TITLE
Changing the value of the alpha channel used in getCanvasFp

### DIFF
--- a/fingerprint2.js
+++ b/fingerprint2.js
@@ -679,7 +679,7 @@
         ctx.font = "11pt no-real-font-123";
       }
       ctx.fillText("Cwm fjordbank glyphs vext quiz, \ud83d\ude03", 2, 15);
-      ctx.fillStyle = "rgba(102, 204, 0, 0.7)";
+      ctx.fillStyle = "rgba(102, 204, 0, 0.2)";
       ctx.font = "18pt Arial";
       ctx.fillText("Cwm fjordbank glyphs vext quiz, \ud83d\ude03", 4, 45);
 


### PR DESCRIPTION
This change tries to fix the problem of the random generation of two different fingerprint hashes for a same device. This seems to be happening in Firefox and iPhone 4. The problem is related to the getCanvasFp function (the result of the call to the canvas.toDataURL) and, in paticular, to the value used for the alpha channel of the ctx.fillStyle. After testing the library on many different devices (Firefox, Chrome, and Explorer -desktop-, iPhone4, iPhone 6+, iPad Mini, Samsung Galaxy S4, Samsung Galaxy S6), it seems that changing this vale from 0.7 to 0.2 makes the hash stable.