### PR TITLE
fix js error if pair.value is undefined

### DIFF
--- a/fingerprint2.js
+++ b/fingerprint2.js
@@ -111,7 +111,7 @@
         var values = [];
         that.each(newKeys, function(pair) {
           var value = pair.value;
-          if (typeof pair.value.join !== "undefined") {
+          if (pair.value && typeof pair.value.join !== "undefined") {
             value = pair.value.join(";");
           }
           values.push(value);


### PR DESCRIPTION
fix js error if pair.value is undefined, which blocks generating fingerprint.