### PR TITLE
Use 'instanceOf' to make the use of 'new' optional

### DIFF
--- a/fingerprint2.js
+++ b/fingerprint2.js
@@ -54,6 +54,9 @@
     };
   }
   var Fingerprint2 = function(options) {
+
+    if (!(this instanceof Fingerprint2)) return new Fingerprint2(options)
+
     var defaultOptions = {
       swfContainerId: "fingerprintjs2",
       swfPath: "flash/compiled/FontList.swf",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fingerprintjs2",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Modern & flexible browser fingerprinting library",
   "main": "dist/fingerprint2.min.js",
   "devDependencies": {

--- a/specs/specs.js
+++ b/specs/specs.js
@@ -43,6 +43,12 @@ describe("Fingerprint2", function () {
     });
   });
 
+  describe("without new keyword", function () {
+    it("creates a new instance of FP2", function () {
+      expect(Fingerprint2()).not.toBeNull();
+    });
+  })
+
   describe("get", function () {
     describe("default options", function () {
       it("calculates fingerprint", function (done) {


### PR DESCRIPTION
I first tried to use this library like
```js
import fingerPrint from `~/fingerprintjs2`

fingerPrint().get((result, components) => {
  console.log(result, components)
})
```

I stopped in the error `Uncaught TypeError: Cannot read property 'extend' of undefined`, I did read about this on JavaScript Patterns.

With this change, will be possible to use fingerPrint without the use of `new` and the snippets above will work.