### PR TITLE
￼￼hasIndexedDB fails within iframe when third party cookies are off

### DIFF
--- a/fingerprint2.js
+++ b/fingerprint2.js
@@ -626,7 +626,11 @@
       }
     },
     hasIndexedDB: function (){
-      return !!window.indexedDB;
+      try {
+        return !!window.indexedDB;  
+      } catch(e) {
+        return true; // SecurityError when referencing it means it exists
+      }
     },
     getNavigatorCpuClass: function () {
       if(navigator.cpuClass){


### PR DESCRIPTION
Similar to the other `try`/`catch` statements used for checking storage, we need to wrap `hasIndexedDB`.

When third party cookies are disabled and fingerprintjs runs in an iframe, trying to access `indexedDB` would result in an exception preventing the fingerprint from bring calculated.