### PR TITLE
Add support for navigator.deviceMemory

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ To start a web server you can try using one of the following:
 24. Touch screen detection and capabilities
 25. Pixel Ratio
 26. System's total number of logical processors available to the user agent.
+27. [Device memory](https://w3c.github.io/device-memory/)
 
 
 By default, JS font detection will only detect up to 65 installed fonts. If you want to improve the font detection,

--- a/fingerprint2.js
+++ b/fingerprint2.js
@@ -62,6 +62,7 @@
       keys = this.userAgentKey(keys)
       keys = this.languageKey(keys)
       keys = this.colorDepthKey(keys)
+      keys = this.deviceMemoryKey(keys)
       keys = this.pixelRatioKey(keys)
       keys = this.hardwareConcurrencyKey(keys)
       keys = this.screenResolutionKey(keys)
@@ -127,6 +128,15 @@
         keys.addPreprocessedComponent({key: 'color_depth', value: window.screen.colorDepth || -1})
       }
       return keys
+    },
+    deviceMemoryKey: function (keys) {
+      if (!this.options.excludeDeviceMemory) {
+        keys.addPreprocessedComponent({key: 'device_memory', value: this.getDeviceMemory()})
+      }
+      return keys
+    },
+    getDeviceMemory: function () {
+      return navigator.deviceMemory || -1
     },
     pixelRatioKey: function (keys) {
       if (!this.options.excludePixelRatio) {

--- a/specs/specs.js
+++ b/specs/specs.js
@@ -88,6 +88,15 @@ describe("Fingerprint2", function () {
         });
       });
 
+      it("does not use deviceMemory when excluded", function (done) {
+        var fp2 = new Fingerprint2({excludeDeviceMemory: true});
+        spyOn(fp2, "getDeviceMemory");
+        fp2.get(function (result) {
+          expect(fp2.getDeviceMemory).not.toHaveBeenCalled();
+          done();
+        });
+      });
+
       it("does not use screen resolution when excluded", function (done) {
         var fp2 = new Fingerprint2({excludeScreenResolution: true});
         spyOn(fp2, "getScreenResolution");


### PR DESCRIPTION
Chrome 63 Beta added support for for the Device Memory API. This commit
adds navigator.deviceMemory as a fingerprint source.

https://blog.chromium.org/2017/10/chrome-63-beta-dynamic-module-imports_27.html
https://w3c.github.io/device-memory/