### PR TITLE
Behavior order

### DIFF
--- a/fingerprint2.js
+++ b/fingerprint2.js
@@ -213,7 +213,7 @@
     },
     addBehaviorKey: function (keys) {
       // body might not be defined at this point or removed programmatically
-      if (document.body && !this.options.excludeAddBehavior && document.body.addBehavior) {
+      if (!this.options.excludeAddBehavior && document.body && document.body.addBehavior) {
         keys.addPreprocessedComponent({key: 'add_behavior', value: 1})
       }
       return keys


### PR DESCRIPTION
When running in react-native, the document might not exist.  

I needed to move the validation to after the option excludeAddbehavior