### PR TITLE
Change testString in font detection to enhance it's precision

### DIFF
--- a/fingerprint2.js
+++ b/fingerprint2.js
@@ -380,7 +380,7 @@
 
         // we use m or w because these two characters take up the maximum width.
         // And we use a LLi so that the same matching fonts can get separated
-        var testString = 'mmmmmmwwwwwwMMMMMMWWWWWWlililiLILILI111lllIII'
+        var testString = 'mMwWlLiI0123456789'
 
         // we test using 72px font size, we may use any size. I guess larger the better.
         var testSize = '72px'

--- a/fingerprint2.js
+++ b/fingerprint2.js
@@ -380,7 +380,7 @@
 
         // we use m or w because these two characters take up the maximum width.
         // And we use a LLi so that the same matching fonts can get separated
-        var testString = 'mmmmmmmmmmlli'
+        var testString = 'mmmmmmwwwwwwMMMMMMWWWWWWlililiLILILI111lllIII'
 
         // we test using 72px font size, we may use any size. I guess larger the better.
         var testSize = '72px'

--- a/fingerprint2.js
+++ b/fingerprint2.js
@@ -380,7 +380,7 @@
 
         // we use m or w because these two characters take up the maximum width.
         // And we use a LLi so that the same matching fonts can get separated
-        var testString = 'aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpPqQrRsStTuUvVwWxXyYzZ0123456789'
+        var testString = 'mmmmmmmmmmlli'
 
         // we test using 72px font size, we may use any size. I guess larger the better.
         var testSize = '72px'

--- a/fingerprint2.js
+++ b/fingerprint2.js
@@ -380,7 +380,7 @@
 
         // we use m or w because these two characters take up the maximum width.
         // And we use a LLi so that the same matching fonts can get separated
-        var testString = 'mMwWlLiI0123456789'
+        var testString = 'aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpPqQrRsStTuUvVwWxXyYzZ0123456789'
 
         // we test using 72px font size, we may use any size. I guess larger the better.
         var testSize = '72px'
@@ -407,7 +407,21 @@
           s.style.position = 'absolute'
           s.style.left = '-9999px'
           s.style.fontSize = testSize
+
+          // css font reset to reset external styles
+          s.style.fontStyle = 'normal'
+          s.style.fontWeight = 'normal'
+          s.style.letterSpacing = 'normal'
+          s.style.lineBreak = 'auto'
           s.style.lineHeight = 'normal'
+          s.style.texTransform = 'none'
+          s.style.textAlign = 'left'
+          s.style.textDecoration = 'none'
+          s.style.textShadow = 'none'
+          s.style.whiteSpace = 'normal'
+          s.style.wordBreak = 'normal'
+          s.style.wordSpacing = 'normal'
+
           s.innerHTML = testString
           return s
         }


### PR DESCRIPTION
After playing with font detection for a while, I found out, that original testString missed one of default fonts on my machine ('Arial Hebrew' on MB Pro 2016)
It makes sense that not only size of font but number/type of characters matters a lot in this font detection strategy
Perhaps adding alphabet in both cases would be even better

What do you think?