### PR TITLE
getAdBlock returns null instead of false

### DIFF
--- a/fingerprint2.js
+++ b/fingerprint2.js
@@ -889,6 +889,9 @@
         document.body.appendChild(ads)
         result = document.getElementsByClassName('adsbox')[0].offsetHeight === 0
         document.body.removeChild(ads)
+        If (result == null){
+          result=false
+        }
       } catch (e) {
         result = false
       }


### PR DESCRIPTION
I do not know the exact condition causing this but result is being set to null and returning null rather than false.  To be consistent and prevent the index.html example from sending a null to .toString, check if null, and set to false if necessary.