### PR TITLE
Added timezone from the Internationalization API

### DIFF
--- a/fingerprint2.js
+++ b/fingerprint2.js
@@ -81,6 +81,7 @@
       keys = this.screenResolutionKey(keys)
       keys = this.availableScreenResolutionKey(keys)
       keys = this.timezoneOffsetKey(keys)
+      keys = this.timezoneKey(keys)
       keys = this.sessionStorageKey(keys)
       keys = this.localStorageKey(keys)
       keys = this.indexedDbKey(keys)
@@ -288,6 +289,16 @@
     timezoneOffsetKey: function (keys) {
       if (!this.options.excludeTimezoneOffset) {
         keys.addPreprocessedComponent({key: 'timezone_offset', value: new Date().getTimezoneOffset()})
+      }
+      return keys
+    },
+    timezoneKey: function (keys) {
+      if (!this.options.excludeTimezone) {
+        var value = null
+        if (window.Intl && window.Intl.DateTimeFormat) {
+          value = new window.Intl.DateTimeFormat().resolvedOptions().timeZone
+        }
+        keys.addPreprocessedComponent({key: 'timezone', value: value})
       }
       return keys
     },

--- a/specs/specs.js
+++ b/specs/specs.js
@@ -145,6 +145,14 @@ describe('Fingerprint2', function () {
           done()
         })
       })
+
+      it('does not use timezone when excluded', function (done) {
+        var fp2 = new Fingerprint2({excludeTimezone: true})
+        fp2.get(function (result, components) {
+          expect(components).not.toContain(jasmine.objectContaining({"key": "timezone"}))
+          done()
+        })
+      })
     })
 
     describe('returns components', function () {


### PR DESCRIPTION
This PR adds the timezone from `Intl.DateTimeFormat().resolvedOptions().timeZone`.
For most systems/browser this will return the timezone in the  IANA time zone database format, fe: "Europe/Berlin" or "America/Los_Angeles".

Disabled by the "excludeTimezone" option.

More info:
[Intl.DateTimeFormat](https://www.ecma-international.org/ecma-402/1.0/#sec-12)
Ref. Issue: #356