### PR TITLE
Check for existance of `window` so we don't break server side render

### DIFF
--- a/fingerprint2.js
+++ b/fingerprint2.js
@@ -18,7 +18,7 @@
 
 (function (name, context, definition) {
   'use strict'
-  if (typeof window.define === 'function' && window.define.amd) { window.define(definition) } else if (typeof module !== 'undefined' && module.exports) { module.exports = definition() } else if (context.exports) { context.exports = definition() } else { context[name] = definition() }
+  if (typeof window !== 'undefined' && typeof window.define === 'function' && window.define.amd) { window.define(definition) } else if (typeof module !== 'undefined' && module.exports) { module.exports = definition() } else if (context.exports) { context.exports = definition() } else { context[name] = definition() }
 })('Fingerprint2', this, function () {
   'use strict'
   /**


### PR DESCRIPTION
I was having issues `import`ing fingerprint2 when using using server side rendering.

I've created an example repo at https://github.com/alexhayes/fingerprint2-broken-ssr which demonstrates this issue.