### PR TITLE
Fixing the build failure when used in other appss, "dist/" folder doe…

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/Valve/fingerprintjs2/issues"
   },
   "homepage": "https://github.com/Valve/fingerprintjs2",
-  "main": "dist/fingerprint2.min.js",
+  "main": "fingerprint2.js",
   "devDependencies": {
     "gulp": "^4.0.0",
     "gulp-util": "^3.0.8",


### PR DESCRIPTION
Fixing the build failure when used in other apps, "dist/fingerprint2.min.js" doesn't exist.

Typically we don't need minified version as **main** script that it gets minimized by host app anyway.
