### PR TITLE
add guard against string value being treated as array

### DIFF
--- a/fingerprint2.js
+++ b/fingerprint2.js
@@ -1,5 +1,5 @@
 /*
-* Fingerprintjs2 2.0.6 - Modern & flexible browser fingerprint library v2
+* Fingerprintjs2 2.0.7 - Modern & flexible browser fingerprint library v2
 * https://github.com/Valve/fingerprintjs2
 * Copyright (c) 2015 Valentin Vasilyev (valentin.vasilyev@outlook.com)
 * Licensed under the MIT (http://www.opensource.org/licenses/mit-license.php) license.
@@ -1388,14 +1388,9 @@
               return [p[0], p[1], mimeTypes].join('::')
             })})
         } else if (['canvas', 'webgl'].indexOf(component.key) !== -1) {
-          newComponents.push({key: component.key, value: component.value.join('~')})
+          if (component.value && typeof component.value.join === 'function') newComponents.push({key: component.key, value: component.value.join('~')})
         } else if (['sessionStorage', 'localStorage', 'indexedDb', 'addBehavior', 'openDatabase'].indexOf(component.key) !== -1) {
-          if (component.value) {
-            newComponents.push({key: component.key, value: 1})
-          } else {
-            // skip
-            continue
-          }
+          if (component.value) newComponents.push({key: component.key, value: 1})
         } else {
           if (component.value) {
             newComponents.push(component.value.join ? {key: component.key, value: component.value.join(';')} : component)
@@ -1410,6 +1405,6 @@
   }
 
   Fingerprint2.x64hash128 = x64hash128
-  Fingerprint2.VERSION = '2.0.6'
+  Fingerprint2.VERSION = '2.0.7'
   return Fingerprint2
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fingerprintjs2",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Modern & flexible browser fingerprinting library",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR addresses https://github.com/Valve/fingerprintjs2/issues/432 where canvas might possibly be throwing and returning an error string instead of an expected error.

The hotfix simply guards against the value not being an array and instead continues with the program flow.

This does not necessarily fix the underlying root cause, merely ensures it does not break full execution.