### PR TITLE
Various changes dealing with false positives on hasLiedOs() and hasLiedBrowser()

### DIFF
--- a/fingerprint2.js
+++ b/fingerprint2.js
@@ -1121,25 +1121,25 @@
     // We extract the OS from the user agent (respect the order of the if else if statement)
     if (userAgent.indexOf('windows phone') >= 0) {
       os = 'Windows Phone'
-    } else if (userAgent.indexOf('win') >= 0) {
+    } else if (userAgent.indexOf('windows') >= 0 || userAgent.indexOf('win16') >= 0 || userAgent.indexOf('win32') >= 0 || userAgent.indexOf('win64') >= 0 || userAgent.indexOf('win95') >= 0 || userAgent.indexOf('win98') >= 0 || userAgent.indexOf('winnt') >= 0 || userAgent.indexOf('wow64') >= 0) {
       os = 'Windows'
     } else if (userAgent.indexOf('android') >= 0) {
       os = 'Android'
-    } else if (userAgent.indexOf('linux') >= 0 || userAgent.indexOf('cros') >= 0) {
+    } else if (userAgent.indexOf('linux') >= 0 || userAgent.indexOf('cros') >= 0 || userAgent.indexOf('x11') >= 0) {
       os = 'Linux'
-    } else if (userAgent.indexOf('iphone') >= 0 || userAgent.indexOf('ipad') >= 0) {
+    } else if (userAgent.indexOf('iphone') >= 0 || userAgent.indexOf('ipad') >= 0 || userAgent.indexOf('ipod') >= 0 || userAgent.indexOf('crios') >= 0 || userAgent.indexOf('fxios') >= 0) {
       os = 'iOS'
-    } else if (userAgent.indexOf('mac') >= 0) {
+    } else if (userAgent.indexOf('macintosh') >= 0 || userAgent.indexOf('mac_powerpc)') >= 0) {
       os = 'Mac'
     } else {
       os = 'Other'
     }
-    // We detect if the person uses a mobile device
+    // We detect if the person uses a touch device
     var mobileDevice = (('ontouchstart' in window) ||
       (navigator.maxTouchPoints > 0) ||
       (navigator.msMaxTouchPoints > 0))
 
-    if (mobileDevice && os !== 'Windows Phone' && os !== 'Android' && os !== 'iOS' && os !== 'Other') {
+    if (mobileDevice && os !== 'Windows' && os !== 'Windows Phone' && os !== 'Android' && os !== 'iOS' && os !== 'Other' && userAgent.indexOf('cros') === -1) {
       return true
     }
 
@@ -1164,12 +1164,17 @@
       return true
     } else if ((platform.indexOf('mac') >= 0 || platform.indexOf('ipad') >= 0 || platform.indexOf('ipod') >= 0 || platform.indexOf('iphone') >= 0) && os !== 'Mac' && os !== 'iOS') {
       return true
+    } else if (platform.indexOf('arm') >= 0 && os === 'Windows Phone') {
+    	return false;
+    } else if (platform.indexOf('pike') >= 0 && userAgent.indexOf('opera mini') >= 0) {
+    	return false;
     } else {
       var platformIsOther = platform.indexOf('win') < 0 &&
         platform.indexOf('linux') < 0 &&
         platform.indexOf('mac') < 0 &&
         platform.indexOf('iphone') < 0 &&
-        platform.indexOf('ipad') < 0
+        platform.indexOf('ipad') < 0 &&
+        platform.indexOf('ipod') < 0
       if (platformIsOther !== (os === 'Other')) {
         return true
       }
@@ -1183,15 +1188,25 @@
 
     // we extract the browser from the user agent (respect the order of the tests)
     var browser
-    if (userAgent.indexOf('firefox') >= 0) {
+    if (userAgent.indexOf('edge/') >= 0 || userAgent.indexOf('iemobile/') >= 0) {
+    	// Unreliable, different versions use EdgeHTML, Webkit, Blink, etc.
+    	return false;
+    } else if (userAgent.indexOf('opera mini') >= 0) {
+    	// Unreliable, different modes use Presto, WebView, Webkit, etc.
+    	return false;
+    } else if (userAgent.indexOf('firefox/') >= 0) {
       browser = 'Firefox'
-    } else if (userAgent.indexOf('opera') >= 0 || userAgent.indexOf('opr') >= 0) {
+    } else if (userAgent.indexOf('opera/') >= 0 || userAgent.indexOf(' opr/') >= 0) {
       browser = 'Opera'
-    } else if (userAgent.indexOf('chrome') >= 0) {
+    } else if (userAgent.indexOf('chrome/') >= 0) {
       browser = 'Chrome'
-    } else if (userAgent.indexOf('safari') >= 0) {
-      browser = 'Safari'
-    } else if (userAgent.indexOf('trident') >= 0) {
+    } else if (userAgent.indexOf('safari/') >= 0) {
+    	if (userAgent.indexOf('android 1.') >= 0 || userAgent.indexOf('android 2.') >= 0 || userAgent.indexOf('android 3.') >= 0 || userAgent.indexOf('android 4.') >= 0) {
+	      browser = 'AOSP'
+    	} else {
+	      browser = 'Safari'
+    	}
+    } else if (userAgent.indexOf('trident/') >= 0) {
       browser = 'Internet Explorer'
     } else {
       browser = 'Other'
@@ -1207,7 +1222,7 @@
       return true
     } else if (tempRes === 39 && browser !== 'Internet Explorer' && browser !== 'Other') {
       return true
-    } else if (tempRes === 33 && browser !== 'Chrome' && browser !== 'Opera' && browser !== 'Other') {
+    } else if (tempRes === 33 && browser !== 'Chrome' && browser !== 'AOSP' && browser !== 'Opera' && browser !== 'Other') {
       return true
     }
 


### PR DESCRIPTION
This PR deals with the following issues:

hasLiedOs meta issue
https://github.com/Valve/fingerprintjs2/issues/497

hasLiedOs is unreliable and can be easily improved
https://github.com/Valve/fingerprintjs2/issues/493

hasLiedBrowser Opera-check is unreliable
https://github.com/Valve/fingerprintjs2/issues/494

hasLiedBrowser is misdetecting pre-4.4 Android stock browser (and WebView) as Safari
https://github.com/Valve/fingerprintjs2/issues/495

hasLiedBrowser is unreliable for Windows Phone Edge and Opera Mini
https://github.com/Valve/fingerprintjs2/issues/496

has lied OS & has lied resolution accuracy
https://github.com/Valve/fingerprintjs2/issues/396

Discussion of the changes:

1) Substring matches for "win" that attempt to detect Windows have been replaced with more specific substrings, in order to avoid detecting anything else containing "win" as "Windows". This is very prevalent in mobile devices that contain vendor name, device model, build, etc.

2) Same as above for "mac" -> replaced with "macintosh" and "mac_powerpc"

3) X11 is added as substring match for Linux.

4) iPod, CriOS (Chrome for iOS) and FxiOS (Firefox for iOS) are added as matches for iOS

5) Windows and CrOS (Chrome OS) are added as valid touch device OS options. Avoids false positives for touch-enabled laptops.

6) Avoids false positives for Windows Phone with platform = "ARM"

7) Avoids false positives for Opera Mini with platform containing "Pike"

8) platformIsOther check takes iPod into account.

9) hasLiedBrowser() avoids checks for Microsoft Edge and Opera Mini, since both use different rendering and JavaScript engines, depending on browser version and execution mode.

10) hasLiedBrowser() uses substrings with slashes to improve matching. Especially important is the change from "opr" to " opr/" to avoid misdetecting Opera when the User-Agent contains "opr"

11) hasLiedBrowser() now attempts to differentiate AOSP (old Android stock browser) which was previously detected as "Safari" even through it is much closer to Chrome (it is based on Chromium source code). The eval.toString().length check for AOSP should be the same as Chrome, however the navigator.productSub check was left out for AOSP, since we cannot be sure what these old devices returned for navigator.productSub without an actual device test (anyone care to test?)